### PR TITLE
chore: replace @public-ui/react with @public-ui/react-v19 for React 19 migration

### DIFF
--- a/csr/react-vite-formik/package.json
+++ b/csr/react-vite-formik/package.json
@@ -12,7 +12,7 @@
 	},
 	"dependencies": {
 		"@public-ui/components": "4.2.1",
-		"@public-ui/react": "4.2.1",
+		"@public-ui/react-v19": "4.2.1",
 		"@public-ui/theme-default": "4.2.1",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",

--- a/csr/react-vite-formik/src/App.tsx
+++ b/csr/react-vite-formik/src/App.tsx
@@ -17,7 +17,7 @@ import {
 	KolInputText,
 	KolSelect,
 	KolTextarea,
-} from '@public-ui/react';
+} from '@public-ui/react-v19';
 import { useState } from 'react';
 import { z } from 'zod';
 import { toFormikValidationSchema } from 'zod-formik-adapter';

--- a/csr/react-vite/package.json
+++ b/csr/react-vite/package.json
@@ -12,7 +12,7 @@
 	},
 	"dependencies": {
 		"@public-ui/components": "4.2.1",
-		"@public-ui/react": "4.2.1",
+		"@public-ui/react-v19": "4.2.1",
 		"@public-ui/theme-default": "4.2.1",
 		"react": "18.3.1",
 		"react-dom": "18.3.1"

--- a/csr/react-vite/src/App.tsx
+++ b/csr/react-vite/src/App.tsx
@@ -1,5 +1,5 @@
 import './App.css';
-import { KolButton } from '@public-ui/react';
+import { KolButton } from '@public-ui/react-v19';
 
 function App() {
 	return (

--- a/kolibri/library/app/package.json
+++ b/kolibri/library/app/package.json
@@ -20,7 +20,7 @@
 		"@public-ui/components": "4.2.1",
 		"@public-ui/library-components": "workspace:*",
 		"@public-ui/library-react": "workspace:*",
-		"@public-ui/react": "4.2.1",
+		"@public-ui/react-v19": "4.2.1",
 		"adopted-style-sheets": "1.1.8",
 		"@types/node": "22.15.32",
 		"@types/react": "18.3.23",

--- a/kolibri/library/app/src/App.tsx
+++ b/kolibri/library/app/src/App.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useLocation } from 'react-router';
 import { Navigate, Route, Routes, useSearchParams } from 'react-router-dom';
 
-import { KolAlert } from '@public-ui/react';
+import { KolAlert } from '@public-ui/react-v19';
 
 import { Sidebar } from './components/Sidebar';
 import { useSetCurrentLocation } from './hooks/useSetCurrentLocation';

--- a/kolibri/library/app/src/components/SampleDescription.tsx
+++ b/kolibri/library/app/src/components/SampleDescription.tsx
@@ -1,7 +1,7 @@
 import type { FC, PropsWithChildren } from 'react';
 import React, { useContext } from 'react';
 
-import { KolIndentedText, KolLink } from '@public-ui/react';
+import { KolIndentedText, KolLink } from '@public-ui/react-v19';
 
 import { HideMenusContext } from '../shares/HideMenusContext';
 

--- a/kolibri/library/app/src/components/Sidebar.tsx
+++ b/kolibri/library/app/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import type { FC, PropsWithChildren } from 'react';
 import React from 'react';
 
-import { KolAccordion, KolButton, KolHeading, KolLink, KolVersion } from '@public-ui/react';
+import { KolAccordion, KolButton, KolHeading, KolLink, KolVersion } from '@public-ui/react-v19';
 
 import DemoPackageJson from '@public-ui/library-components/package.json';
 

--- a/kolibri/library/app/src/components/button/access-key.tsx
+++ b/kolibri/library/app/src/components/button/access-key.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { KolButton } from '@public-ui/react';
+import { KolButton } from '@public-ui/react-v19';
 
 import type { FC } from 'react';
 export const ButtonAccessKey: FC = () => (

--- a/kolibri/library/app/src/components/button/baselined.tsx
+++ b/kolibri/library/app/src/components/button/baselined.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { KolButton } from '@public-ui/react';
+import { KolButton } from '@public-ui/react-v19';
 
 import type { FC } from 'react';
 

--- a/kolibri/library/app/src/components/button/hide-label.tsx
+++ b/kolibri/library/app/src/components/button/hide-label.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { KolButton } from '@public-ui/react';
+import { KolButton } from '@public-ui/react-v19';
 
 import type { FC } from 'react';
 

--- a/kolibri/library/app/src/components/button/icons.tsx
+++ b/kolibri/library/app/src/components/button/icons.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { KolButton } from '@public-ui/react';
+import { KolButton } from '@public-ui/react-v19';
 
 import type { FC } from 'react';
 

--- a/kolibri/library/app/src/components/button/partials/cases.tsx
+++ b/kolibri/library/app/src/components/button/partials/cases.tsx
@@ -1,7 +1,7 @@
 import type { Components } from '@public-ui/components';
 import React, { forwardRef } from 'react';
 
-import { KolButton } from '@public-ui/react';
+import { KolButton } from '@public-ui/react-v19';
 
 export const ButtonCases = forwardRef<HTMLKolButtonElement, Components.KolButton>(function InputCheckboxCases(props, ref) {
 	return (

--- a/kolibri/library/app/src/components/button/width.tsx
+++ b/kolibri/library/app/src/components/button/width.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { KolButton } from '@public-ui/react';
+import { KolButton } from '@public-ui/react-v19';
 
 import type { FC } from 'react';
 

--- a/ssr/astro/package.json
+++ b/ssr/astro/package.json
@@ -22,7 +22,7 @@
 		"@astrojs/preact": "1.2.0",
 		"@leanup/stack": "1.3.49",
 		"@public-ui/components": "4.2.1",
-		"@public-ui/react": "4.2.1",
+		"@public-ui/react-v19": "4.2.1",
 		"@public-ui/theme-default": "4.2.1",
 		"@types/react": "18.2.60",
 		"@types/node": "18.19.19",

--- a/ssr/astro/src/components/Search.tsx
+++ b/ssr/astro/src/components/Search.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import './Search.css';
 
-import { KolAlert, KolIcon, KolKolibri, KolLink } from '@public-ui/react';
+import { KolAlert, KolIcon, KolKolibri, KolLink } from '@public-ui/react-v19';
 
 export default function Search() {
 	return (

--- a/ssr/next.js/package.json
+++ b/ssr/next.js/package.json
@@ -16,7 +16,7 @@
 	"dependencies": {
 		"@leanup/stack": "1.3.49",
 		"@public-ui/components": "4.2.1",
-		"@public-ui/react": "4.2.1",
+		"@public-ui/react-v19": "4.2.1",
 		"@public-ui/theme-default": "4.2.1",
 		"@stencil/core": "2.22.3",
 		"next": "13.5.6",

--- a/ssr/next.js/src/pages/index.tsx
+++ b/ssr/next.js/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { KolAlert, KolIcon, KolKolibri, KolLink } from '@public-ui/react';
+import { KolAlert, KolIcon, KolKolibri, KolLink } from '@public-ui/react-v19';
 import React from 'react';
 import Head from 'next/head';
 


### PR DESCRIPTION
## Summary
- Replaced all occurrences of @public-ui/react with @public-ui/react-v19 in package.json dependencies
- Updated all import statements in source files to use @public-ui/react-v19
- This enables migration to React 19 for all affected templates

## Affected Templates
- csr/react-vite
- csr/react-vite-formik
- ssr/astro
- ssr/next.js
- kolibri/library/app

## Changes
- 18 files changed, 18 insertions(+), 18 deletions(-)

Closes #7a408250