### PR TITLE
fix: update adopted-style-sheets to 1.1.9-rc.22 in CSR templates

### DIFF
--- a/csr/react-vite/package.json
+++ b/csr/react-vite/package.json
@@ -25,7 +25,7 @@
 		"@types/react": "19.2.18",
 		"@types/react-dom": "19.2.4",
 		"@vitejs/plugin-react-swc": "4.3.3",
-		"adopted-style-sheets": "1.1.8",
+		"adopted-style-sheets": "1.1.9-rc.22",
 		"prettier": "3.9.6",
 		"unocss": "66.7.5",
 		"typescript": "5.9.3",

--- a/csr/static-page/package.json
+++ b/csr/static-page/package.json
@@ -10,7 +10,7 @@
 	"devDependencies": {
 		"@public-ui/components": "4.2.1",
 		"@public-ui/theme-default": "4.2.1",
-		"adopted-style-sheets": "1.1.8",
+		"adopted-style-sheets": "1.1.9-rc.22",
 		"cpy-cli": "7.0.0",
 		"npm-run-all2": "9.0.3",
 		"serve": "14.2.6"

--- a/csr/vue-vite/package.json
+++ b/csr/vue-vite/package.json
@@ -19,7 +19,7 @@
 		"@leanup/stack": "1.3.54",
 		"@vitejs/plugin-vue": "6.0.8",
 		"@vue/tsconfig": "0.9.1",
-		"adopted-style-sheets": "1.1.8",
+		"adopted-style-sheets": "1.1.9-rc.22",
 		"prettier": "3.9.6",
 		"unocss": "66.7.5",
 		"typescript": "5.9.3",


### PR DESCRIPTION
## Summary
- Updated adopted-style-sheets from 1.1.8 to 1.1.9-rc.22 in CSR templates to resolve peer dependency conflict with @public-ui/components@4.2.1

## Affected Templates
- csr/static-page
- csr/react-vite
- csr/vue-vite

## Issue
This change resolves the npm ERESOLVE error that prevented users from installing these templates without the --legacy-peer-deps workaround.

Closes #227