### PR TITLE
fix(templates): add missing sass-embedded devDependency to SCSS samples

### DIFF
--- a/csr/preact-vite/package.json
+++ b/csr/preact-vite/package.json
@@ -23,6 +23,7 @@
 		"adopted-style-sheets": "1.1.9-rc.22",
 		"knip": "6.31.0",
 		"prettier": "3.9.6",
+		"sass-embedded": "1.92.1",
 		"stylelint": "16.26.1",
 		"stylelint-config-recommended-scss": "16.0.2",
 		"stylelint-config-standard": "39.0.1",

--- a/csr/react-vite-hook-form/package.json
+++ b/csr/react-vite-hook-form/package.json
@@ -29,6 +29,7 @@
 		"typescript": "5.9.3",
 		"unocss": "66.7.5",
 		"vite": "8.2.0",
+		"sass-embedded": "1.92.1",
 		"stylelint": "16.26.1",
 		"stylelint-config-recommended-scss": "16.0.2",
 		"stylelint-config-standard": "39.0.1",

--- a/csr/react-vite/package.json
+++ b/csr/react-vite/package.json
@@ -32,6 +32,7 @@
 		"typescript": "5.9.3",
 		"vite": "8.2.0",
 		"vitest": "4.1.10",
+		"sass-embedded": "1.92.1",
 		"stylelint": "16.26.1",
 		"stylelint-config-recommended-scss": "16.0.2",
 		"stylelint-config-standard": "39.0.1",

--- a/csr/solid-vite/package.json
+++ b/csr/solid-vite/package.json
@@ -22,6 +22,7 @@
 		"adopted-style-sheets": "1.1.9-rc.22",
 		"knip": "6.31.0",
 		"prettier": "3.9.6",
+		"sass-embedded": "1.92.1",
 		"stylelint": "16.26.1",
 		"stylelint-config-recommended-scss": "16.0.2",
 		"stylelint-config-standard": "39.0.1",

--- a/csr/svelte-vite/package.json
+++ b/csr/svelte-vite/package.json
@@ -26,6 +26,7 @@
 		"prettier-plugin-svelte": "4.1.1",
 		"svelte": "5.56.8",
 		"svelte-check": "4.7.4",
+		"sass-embedded": "1.92.1",
 		"stylelint": "16.26.1",
 		"stylelint-config-recommended-scss": "16.0.2",
 		"stylelint-config-standard": "39.0.1",

--- a/csr/vue-vite/package.json
+++ b/csr/vue-vite/package.json
@@ -27,6 +27,7 @@
 		"unocss": "66.7.5",
 		"typescript": "5.9.3",
 		"vite": "8.2.0",
+		"sass-embedded": "1.92.1",
 		"stylelint": "16.26.1",
 		"stylelint-config-recommended-scss": "16.0.2",
 		"stylelint-config-standard": "39.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       prettier:
         specifier: 3.9.6
         version: 3.9.6
+      sass-embedded:
+        specifier: 1.92.1
+        version: 1.92.1
       stylelint:
         specifier: 16.26.1
         version: 16.26.1(typescript@5.9.3)
@@ -228,6 +231,9 @@ importers:
       prettier:
         specifier: 3.9.6
         version: 3.9.6
+      sass-embedded:
+        specifier: 1.92.1
+        version: 1.92.1
       stylelint:
         specifier: 16.26.1
         version: 16.26.1(typescript@5.9.3)
@@ -292,6 +298,9 @@ importers:
       prettier:
         specifier: 3.9.6
         version: 3.9.6
+      sass-embedded:
+        specifier: 1.92.1
+        version: 1.92.1
       stylelint:
         specifier: 16.26.1
         version: 16.26.1(typescript@5.9.3)
@@ -338,6 +347,9 @@ importers:
       prettier:
         specifier: 3.9.6
         version: 3.9.6
+      sass-embedded:
+        specifier: 1.92.1
+        version: 1.92.1
       stylelint:
         specifier: 16.26.1
         version: 16.26.1(typescript@5.9.3)
@@ -426,6 +438,9 @@ importers:
       prettier-plugin-svelte:
         specifier: 4.1.1
         version: 4.1.1(prettier@3.9.6)(svelte@5.56.8)
+      sass-embedded:
+        specifier: 1.92.1
+        version: 1.92.1
       stylelint:
         specifier: 16.26.1
         version: 16.26.1(typescript@5.9.3)
@@ -484,6 +499,9 @@ importers:
       prettier:
         specifier: 3.9.6
         version: 3.9.6
+      sass-embedded:
+        specifier: 1.92.1
+        version: 1.92.1
       stylelint:
         specifier: 16.26.1
         version: 16.26.1(typescript@5.9.3)
@@ -1009,6 +1027,9 @@ importers:
       prettier:
         specifier: 3.9.6
         version: 3.9.6
+      sass-embedded:
+        specifier: 1.92.1
+        version: 1.92.1
       stylelint:
         specifier: 16.26.1
         version: 16.26.1(typescript@5.9.3)
@@ -13918,8 +13939,7 @@ snapshots:
   '@bruits/satteri-win32-x64-msvc@0.9.5':
     optional: true
 
-  '@bufbuild/protobuf@2.5.2':
-    optional: true
+  '@bufbuild/protobuf@2.5.2': {}
 
   '@cacheable/memory@2.2.0':
     dependencies:
@@ -18089,8 +18109,7 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
-  buffer-builder@0.2.0:
-    optional: true
+  buffer-builder@0.2.0: {}
 
   buffer-crc32@0.2.13: {}
 
@@ -18461,8 +18480,7 @@ snapshots:
 
   colorette@2.0.20: {}
 
-  colorjs.io@0.5.2:
-    optional: true
+  colorjs.io@0.5.2: {}
 
   colors-cli@1.0.33: {}
 
@@ -24159,7 +24177,6 @@ snapshots:
       sass-embedded-unknown-all: 1.92.1
       sass-embedded-win32-arm64: 1.92.1
       sass-embedded-win32-x64: 1.92.1
-    optional: true
 
   sass@1.77.4:
     dependencies:
@@ -25101,10 +25118,8 @@ snapshots:
   sync-child-process@1.0.2:
     dependencies:
       sync-message-port: 1.1.3
-    optional: true
 
-  sync-message-port@1.1.3:
-    optional: true
+  sync-message-port@1.1.3: {}
 
   synckit@0.9.3:
     dependencies:
@@ -25796,8 +25811,7 @@ snapshots:
 
   validate-npm-package-name@7.0.2: {}
 
-  varint@6.0.0:
-    optional: true
+  varint@6.0.0: {}
 
   vary@1.1.2: {}
 

--- a/ssr/next.js/package.json
+++ b/ssr/next.js/package.json
@@ -29,6 +29,7 @@
 		"prettier": "3.9.6",
 		"unocss": "66.7.5",
 		"typescript": "5.9.3",
+		"sass-embedded": "1.92.1",
 		"stylelint": "16.26.1",
 		"stylelint-config-recommended-scss": "16.0.2",
 		"stylelint-config-standard": "39.0.1",


### PR DESCRIPTION
## Problem

Several CSR/SSR starter templates compile SCSS (e.g. `import './style.scss'`) but **none of them declared `sass-embedded`** as a direct dependency. They compiled only because `vite` ships `sass-embedded` as a *transitive **optional** dependency*. That is fragile and breaks under:

- `pnpm install --prod` / installs that skip optional deps,
- different pnpm hoisting / isolated-install configurations,
- any future Vite release that drops the optional peer.

## Change

Add `"sass-embedded": "1.92.1"` as an explicit `devDependency` to the samples that actually compile SCSS:

| Sample | Notes |
| --- | --- |
| `csr/preact-vite` | imports `style.scss` via Vite |
| `csr/react-vite` | imports `style.scss` via Vite |
| `csr/react-vite-hook-form` | imports `style.scss` via Vite |
| `csr/solid-vite` | imports `style.scss` via Vite |
| `csr/svelte-vite` | imports `style.scss` via Vite |
| `csr/vue-vite` | imports `style.scss` via Vite |
| `ssr/next.js` | imports `../style.scss`; Next's bundled sass-loader probes for `sass-embedded` first and accepts it |

Pinned to `1.92.1` (exact, matching the already-resolved version → no version drift, minimal lockfile change) and following the repo's exact-pin convention. The lockfile change is limited to the 7 new direct-dep entries plus the correct removal of `optional: true` from the `sass-embedded@1.92.1` snapshot (and the cascading optional-flag flip on its own transitive deps).

## Deliberately excluded

- **`csr/angular-cli`** — `@angular/build@21.2.19` depends on `sass` directly (hard dependency), so Angular compiles SCSS robustly without the template declaring it.
- **`ssr/astro`** — `src/style.scss` is an orphan: it is not imported anywhere; Astro uses static `<link>` stylesheets. ⚠️ Possible follow-up: remove the orphan file or wire it up.
- **`ssr/express`, `ssr/remix`, `csr/react-standalone`, `csr/static-page`** — no SCSS.

## Verification

- ✅ `npm run build` green for all 7 affected samples (incl. `next build`).
- ✅ `knip` (`unused`) green for preact/solid/svelte/vue (exit 0) — `sass-embedded` is not flagged as unused.
- ✅ Lockfile self-consistent (`pnpm install` clean).
- ✅ Spiegel-/doc check: no README/AGENTS/`.defaults` mention sass → no doc drift.

## Note on `next.js`

Next.js only declares `sass` (dart-sass) as an optional peer, not `sass-embedded`. Its bundled `sass-loader`'s `getDefaultSassImplementation()` does, however, `require.resolve('sass-embedded')` first and accepts it as a valid implementation — so when `sass-embedded` is present, Next will prefer it. Adding it makes the Sass compiler explicit and consistent with the Vite samples. Flagging here in case a maintainer prefers `sass` (dart-sass) for `next.js` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)